### PR TITLE
Add config header file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ For more on how config files work see the [mbed OS docs](https://github.com/ARMm
 
 ## Troubleshooting
 - Use the `-v` flag for verbose debug and failure messages that can help you troubleshoot. 
+- To enable debug messages, set ``DEBUG_MSG`` to 1 in the ./mbed_app.json file
 - Try running a clean build with `mbed test --clean -n tests-* --app-config .\mbed_app.json -v`
 - Make sure your board is detected to run tests. Use the `mbed detect` command to verify your board is recognized and has a COM port assigned. If the Serial driver isn't working then tests cant run. 
 - make sure you are using the latest version of greentea and mbed-cli. Try running `pip install -U mbed-cli mbed-ls mbed-greentea` to update them all to their latest versions. 

--- a/TESTS/API/AnalogIn/AnalogIn.cpp
+++ b/TESTS/API/AnalogIn/AnalogIn.cpp
@@ -21,6 +21,7 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#include "ci_test_config.h"
 //#include "rtos.h"
 
 using namespace utest::v1;
@@ -38,14 +39,14 @@ void AnalogInput_Test()
     outputs = 0;
     float prev_value = 0;
     for(x = 0; x<5; x++) {
-//        printf("X=%d\n",x);
+        DEBUG_PRINTF("X=%d\n",x);
         prev_value = ain.read();
         y = (y<<1) + 1;
         outputs = y;
-//        printf("outputs=0x%x\nprevValue=%f\nain=%f\n\n",y,prev_value,ain.read());
+        DEBUG_PRINTF("outputs=0x%x\nprevValue=%f\nain=%f\n\n",y,prev_value,ain.read());
         TEST_ASSERT_MESSAGE(ain.read() > prev_value,"Analog Input did not increment. Check that you have assigned valid pins in mbed_app.json file")
     }
-//    printf("Finished the Test\n");
+    DEBUG_PRINTF("Finished the Test\n");
     TEST_ASSERT(true);
 }
 

--- a/TESTS/API/AnalogOut/AnalogOut.cpp
+++ b/TESTS/API/AnalogOut/AnalogOut.cpp
@@ -25,6 +25,7 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#include "ci_test_config.h"
 //#include "rtos.h"
 
 using namespace utest::v1;
@@ -42,13 +43,13 @@ void AnalogOutput_Test()
     valueOff = ain.read();
     aout = 0.5;
     valueOn = ain.read();
-    printf("\r\n***** valueOff = %f, valueOn = %f \r\n",valueOff, valueOn);
+    DEBUG_PRINTF("\r\n***** valueOff = %f, valueOn = %f \r\n",valueOff, valueOn);
     TEST_ASSERT_MESSAGE((0.4f < valueOn) && (0.6f > valueOn), "Value is not in expected range of ~0.5f");
     TEST_ASSERT_MESSAGE(valueOn > valueOff,"Value has not increased, expected 0.5");
     valueOff = ain.read();
     aout = 1.0;
     valueOn = ain.read();
-    printf("\r\n***** valueOff = %f, valueOn = %f \r\n",valueOff, valueOn);
+    DEBUG_PRINTF("\r\n***** valueOff = %f, valueOn = %f \r\n",valueOff, valueOn);
     TEST_ASSERT_MESSAGE((0.9f < valueOn) && (1.1f > valueOn), "Value is not in expected range of ~0.5f");
     TEST_ASSERT_MESSAGE(valueOn > valueOff,"Value has not increased, expected 1.0");
 }

--- a/TESTS/API/BusInOut/BusInOut.cpp
+++ b/TESTS/API/BusInOut/BusInOut.cpp
@@ -18,6 +18,7 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#include "ci_test_config.h"
 
 using namespace utest::v1;
 
@@ -36,7 +37,7 @@ void busout_define_test(){
     bout = 0;
     volatile int x = 0;
     while(x < 0xFF){
-        //printf("\r\n*********\r\nvalue of x is: 0x%x\r\n********\r\n",x);
+        DEBUG_PRINTF("\r\n*********\r\nvalue of x is: 0x%x\r\n********\r\n",x);
         x++;
         bout.write(x);
     }
@@ -60,7 +61,7 @@ void businout_define_test(){
         bio2.input();
         wait(1);
         volatile int y = bio2.read();
-        //printf("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
+        DEBUG_PRINTF("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
         TEST_ASSERT_MESSAGE(y == x,"Value read on bus does not equal value written. ");
     }
 
@@ -73,7 +74,7 @@ void businout_define_test(){
         bio1.input();
         wait(1);
         volatile int y = bio1.read();
-        //printf("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
+        DEBUG_PRINTF("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
         TEST_ASSERT_MESSAGE(y == x,"Value read on bus does not equal value written. ");
     }
 
@@ -89,7 +90,7 @@ void businout_bidirectional_test(){
     while(x < 0x0F){
         x++;
         bout.write(x);
-        //printf("\r\n*********\r\nvalue of bin,bout,x is: 0x%x, 0x%x, 0x%x\r\n********\r\n",bin.read(),bout.read(),x);
+        DEBUG_PRINTF("\r\n*********\r\nvalue of bin,bout,x is: 0x%x, 0x%x, 0x%x\r\n********\r\n",bin.read(),bout.read(),x);
         TEST_ASSERT_MESSAGE(bin.read() == bout.read(),"Value read on bin does not equal value written on bout. ")
     }
     TEST_ASSERT_MESSAGE(true,"The fact that it hasnt error out proves this passes the sniff test");

--- a/TESTS/API/I2C/I2C.cpp
+++ b/TESTS/API/I2C/I2C.cpp
@@ -25,6 +25,7 @@
 #include "utest.h"
 #include "LM75B.h"
 #include <I2CEeprom.h>
+#include "ci_test_config.h"
 
 using namespace utest::v1;
 
@@ -36,7 +37,7 @@ void init_string(char* buffer, int len)
         buffer[x] = 'A' + (rand() % 26);
     }
     buffer[len-1] = 0; // add \0 to end of string
-    //printf("\r\n****\r\nBuffer Len = `%d`, String = `%s`\r\n****\r\n",len,buffer);
+    DEBUG_PRINTF("\r\n****\r\nBuffer Len = `%d`, String = `%s`\r\n****\r\n",len,buffer);
 }
 
 // a test to see if the temperature can be read. A I2C failure returns a 0
@@ -45,7 +46,7 @@ void test_lm75b()
 {
     LM75B  temperature(sda, scl);
     float temp = temperature.temp();
-    printf("\r\n****\r\nTEST LM75B : Temperature Read = `%f`\r\n****\r\n",temp);
+    DEBUG_PRINTF("\r\n****\r\nTEST LM75B : Temperature Read = `%f`\r\n****\r\n",temp);
     TEST_ASSERT_MESSAGE(0 != temperature.open(),"Failed to open sensor");
     //TEST_ASSERT_MESSAGE(NULL != temperature.temp(),"Invalid value NULL returned");
     // TEST_ASSERT_MESSAGE(50 > temperature.temp(),"Its too Hot (>10C), Faulty Sensor?");
@@ -66,7 +67,7 @@ void flash_WR()
     for(int x = 0; x< size_of_data;x++){
         read_string[x] = 0;
     }
-    //printf("\r\n****\r\n Test String = `%s` \r\n****\r\n",test_string);
+    DEBUG_PRINTF("\r\n****\r\n Test String = `%s` \r\n****\r\n",test_string);
 
     num_written = memory.write(address,(char *)test_string,size_of_data);
     num_read = memory.read(address,(char *)read_string,size_of_data);
@@ -76,7 +77,8 @@ void flash_WR()
     TEST_ASSERT_EQUAL_STRING_MESSAGE((char *)test_string,(char *)read_string,"String read does not match the string written");
     TEST_ASSERT_EQUAL_STRING_MESSAGE((char *)read_string,(char *)test_string,"String read does not match the string written");
     TEST_ASSERT_EQUAL_MESSAGE(num_written,num_read,"Number of bytes written does not match the number of bytes read");
-    printf("\r\n****\r\n Address = `%d`\r\n Len = `%d`\r\n Num Bytes Written = `%d` \r\n Num Bytes Read = `%d` \r\n Written String = `%s` \r\n Read String = `%s` \r\n****\r\n",address,size_of_data,num_written,num_read,test_string,read_string);
+    DEBUG_PRINTF("\r\n****\r\n Address = `%d`\r\n Len = `%d`\r\n Num Bytes Written = `%d` \r\n Num Bytes Read = `%d` \r\n Written String = `%s` \r\n Read String = `%s` \r\n****\r\n",address,size_of_data,num_written,num_read,test_string,read_string);
+
 }
 
 // Test single byte R/W
@@ -90,7 +92,7 @@ void single_byte_WR()
     int w = 0;
     w = memory.write(address,test);
     r = memory.read(address,read);
-    printf("\r\n****\r\n Num Bytes Read = %d \r\n Num Bytes Written = %d \r\n Read byte = `%c` \r\n Written Byte = `%c` \r\n****\r\n",r,w,read,test);
+    DEBUG_PRINTF("\r\n****\r\n Num Bytes Read = %d \r\n Num Bytes Written = %d \r\n Read byte = `%c` \r\n Written Byte = `%c` \r\n****\r\n",r,w,read,test);
 
     TEST_ASSERT_EQUAL_MESSAGE(test,read,"Character Read does not equal character written!");
     TEST_ASSERT_MESSAGE(test == read, "character written does not match character read")

--- a/TESTS/API/InterruptIn/InterruptIn.cpp
+++ b/TESTS/API/InterruptIn/InterruptIn.cpp
@@ -22,6 +22,7 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#include "ci_test_config.h"
 //#include "rtos.h"
 
 using namespace utest::v1;
@@ -32,7 +33,7 @@ volatile bool result = false;
 void cbfn(void)
 {
     result = true;
-    //printf("\t**** Interrupt Triggered!\n");
+    DEBUG_PRINTF("\t**** Interrupt Triggered!\n");
 }
 
 // Template to check Falling edge and Rising edge interrupts.
@@ -44,23 +45,23 @@ void InterruptInTest()
     DigitalOut dout(dout_pin);
 
     // Test Rising Edge InterruptIn
-    //printf("***** Rising Edge Test \n");
+    DEBUG_PRINTF("***** Rising Edge Test \n");
     dout = 0;
     result = false;
     intin.rise(cbfn);
     dout = 1;
     wait(0); // dummy wait to get volatile result value
-    //printf("Value of result is : %d\n",result);
+    DEBUG_PRINTF("Value of result is : %d\n",result);
     TEST_ASSERT_MESSAGE(result,"cbfn was not triggered on rising edge of pin");
 
     // Test Falling Edge InterruptIn
-    //printf("***** Falling Edge Test \n");
+    DEBUG_PRINTF("***** Falling Edge Test \n");
     dout = 1;
     result = false;
     intin.fall(cbfn);
     dout = 0;
     wait(0); // dummy wait to get volatile result value
-    //printf("Value of result is : %d\n",result);
+    DEBUG_PRINTF("Value of result is : %d\n",result);
     TEST_ASSERT_MESSAGE(result,"cbfn was not triggered on falling edge of pin");
 }
 

--- a/TESTS/API/Pwm/Pwm.cpp
+++ b/TESTS/API/Pwm/Pwm.cpp
@@ -25,6 +25,7 @@
 #include "unity.h"
 #include "utest.h"
 #include <cmath>
+#include "ci_test_config.h"
 
 using namespace utest::v1;
 
@@ -64,7 +65,7 @@ void PWM_Duty_slave(PinName pwm_out_pin, PinName int_in_pin, int period_in_ms, f
     duty_timer.reset();
     iin.rise(duty_cbfn_rise);
     iin.fall(duty_cbfn_fall);
-    printf("\r\n*****\r\n period = %fs, duty cycle = %f ",(float)period_in_ms / 1000, duty_cycle_percent);
+    DEBUG_PRINTF("\r\n*****\r\n period = %fs, duty cycle = %f ",(float)period_in_ms / 1000, duty_cycle_percent);
 
     pwm.period((float)period_in_ms / 1000); // set PWM period
     duty_timer.start();
@@ -76,13 +77,13 @@ void PWM_Duty_slave(PinName pwm_out_pin, PinName int_in_pin, int period_in_ms, f
     float avgTime = (float)duty_running_count / NUM_TESTS;
     float expectedTime = (float)period_in_ms * duty_cycle_percent;
 
-    printf("\r\n rise_count = %d, fall count = %d, TotalTime = %d, avgTime = %f, expected time = %f ",duty_rise_count,duty_fall_count,duty_running_count,avgTime, expectedTime);
+    DEBUG_PRINTF("\r\n rise_count = %d, fall count = %d, TotalTime = %d, avgTime = %f, expected time = %f ",duty_rise_count,duty_fall_count,duty_running_count,avgTime, expectedTime);
 
     float ten_percent  = expectedTime * 0.1;
     float five_percent = expectedTime * 0.05;
     float one_percent  = expectedTime * 0.01;
 
-    printf("\r\n .10 = %f, .05 = %f, .01 = %f\r\n*****\r\n",ten_percent,five_percent,one_percent);
+    DEBUG_PRINTF("\r\n .10 = %f, .05 = %f, .01 = %f\r\n*****\r\n",ten_percent,five_percent,one_percent);
 
     TEST_ASSERT_MESSAGE( std::abs(expectedTime - avgTime) <= ten_percent, "Greater than 10 percent variance between expected and measured duty cycle");
     TEST_ASSERT_MESSAGE( std::abs(expectedTime - avgTime) <= five_percent,"Greater than 5  percent variance between expected and measured duty cycle");
@@ -100,7 +101,7 @@ void PWM_DutyCycle_Test()
     float x = 0;
     for(x = MIN_DUTY_CYCLE; x < MAX_DUTY_CYCLE; x = x+DUTY_CYCLE_STEP){ // iterate duty cycle test
         PWM_Duty_slave(pwm_out_pin, int_in_pin, period_in_miliseconds, x);
-        //printf("\r\n**************\r\n expected 10 cycles, saw %d rise, %d fall\r\n*******\r\n",duty_rise_count,duty_fall_count);
+        DEBUG_PRINTF("\r\n**************\r\n expected 10 cycles, saw %d rise, %d fall\r\n*******\r\n",duty_rise_count,duty_fall_count);
         //TEST_ASSERT_MESSAGE(100 == rise_count,"Number of cycles not equivalent to amount expected\r\n");
     }
 }
@@ -156,19 +157,19 @@ void PWM_Period_Test()
         one_percent  = 1;
     }
 
-    printf("\r\n*****\r\n rise count = %d, fall count = %d, expected count = %d",rc,fc,expected_count);
-    printf("\r\n .10 = %f, .05 = %f, .01 = %f",ten_percent,five_percent,one_percent);
+    DEBUG_PRINTF("\r\n*****\r\n rise count = %d, fall count = %d, expected count = %d",rc,fc,expected_count);
+    DEBUG_PRINTF("\r\n .10 = %f, .05 = %f, .01 = %f",ten_percent,five_percent,one_percent);
 
     TEST_ASSERT_MESSAGE( std::abs(rc-fc) <= ten_percent, "There was more than 10percent variance in number of rise vs fall cycles");
     TEST_ASSERT_MESSAGE( std::abs(rc-fc) <= five_percent,"There was more than  5percent variance in number of rise vs fall cycles");
     //TEST_ASSERT_MESSAGE( std::abs(rc-fc) <= one_percent, "There was more than  1percent variance in number of rise vs fall cycles");
 
-    printf("\r\n abs(expected-rc) = %d",std::abs(expected_count - rc));
+    DEBUG_PRINTF("\r\n abs(expected-rc) = %d",std::abs(expected_count - rc));
     TEST_ASSERT_MESSAGE( std::abs(expected_count - rc) <= ten_percent, "There was more than 10 percent variance in number of rise cycles seen and number expected.");
     TEST_ASSERT_MESSAGE( std::abs(expected_count - rc) <= five_percent,"There was more than  5 percent variance in number of rise cycles seen and number expected.");
     //TEST_ASSERT_MESSAGE( std::abs(expected_count - rc) <= one_percent, "There was more than  1 percent variance in number of rise cycles seen and number expected.");
 
-    printf("\r\n abs(expected-fc) = %d\r\n*****\r\n",std::abs(expected_count - fc));
+    DEBUG_PRINTF("\r\n abs(expected-fc) = %d\r\n*****\r\n",std::abs(expected_count - fc));
     TEST_ASSERT_MESSAGE( std::abs(expected_count - fc) <= ten_percent, "There was more than 10 percent variance in number of fall cycles seen and number expected.");
     TEST_ASSERT_MESSAGE( std::abs(expected_count - fc) <= five_percent,"There was more than  5 percent variance in number of fall cycles seen and number expected.");
     //TEST_ASSERT_MESSAGE( std::abs(expected_count - fc) <= one_percent, "There was more than  1 percent variance in number of fall cycles seen and number expected.");

--- a/TESTS/API/SPI/SPI.cpp
+++ b/TESTS/API/SPI/SPI.cpp
@@ -21,6 +21,7 @@
 #include "unity.h"
 #include "utest.h"
 #include "SDFileSystem.h" 
+#include "ci_test_config.h"
 
 // check if SPI is supported on this device
 #if !DEVICE_SPI
@@ -43,7 +44,7 @@ void init_string()
     }
     SD_TEST_STRING[SD_TEST_STRING_MAX-1] = 0;
 
-    printf("\r\n****\r\nSD Test String = %s\r\n****\r\n",SD_TEST_STRING);
+    DEBUG_PRINTF("\r\n****\r\nSD Test String = %s\r\n****\r\n",SD_TEST_STRING);
 }
 
 // Test object constructor / destructor
@@ -83,7 +84,7 @@ void test_sd_r()
     TEST_ASSERT_MESSAGE(File != NULL,"SD Card is not present. Please insert an SD Card.");
     fgets(read_string,SD_TEST_STRING_MAX,File); // read string from the file
     //fread(read_string,sizeof(char),sizeof(SD_TEST_STRING),File); // read the string and compare
-    printf("\r\n****\r\nRead '%s' in read test\r\n, string comparison returns %d\r\n****\r\n",read_string,strcmp(read_string,SD_TEST_STRING));
+    DEBUG_PRINTF("\r\n****\r\nRead '%s' in read test\r\n, string comparison returns %d\r\n****\r\n",read_string,strcmp(read_string,SD_TEST_STRING));
     TEST_ASSERT_MESSAGE(strcmp(read_string,SD_TEST_STRING) == 0,"String read does not match string written"); // test that strings match
     fclose(File);    // close file on SD
     TEST_ASSERT(true);

--- a/TESTS/assumptions/PwmOut/PwmOut.cpp
+++ b/TESTS/assumptions/PwmOut/PwmOut.cpp
@@ -25,6 +25,7 @@
 #include "unity.h"
 #include "utest.h"
 #include <cmath>
+#include "ci_test_config.h"
 
 using namespace utest::v1;
 
@@ -62,7 +63,7 @@ void pwm_interrupt_timer_test()
     pwm.write(0.5f); // 50% duty cycle
     timer.stop();
     x.disable_irq(); // Try enabling this if the test fails
-    printf("\r\n*****\r\n Test is complete, returning now, this shouldnt hang, if this ERROR's then your platform has a problem.\r\n*****\r\n");
+    DEBUG_PRINTF("\r\n*****\r\n Test is complete, returning now, this shouldnt hang, if this ERROR's then your platform has a problem.\r\n*****\r\n");
     TEST_ASSERT_MESSAGE(true,"If we exit this test and return then it all works just fine.");
 }
 

--- a/ci_test_config.h
+++ b/ci_test_config.h
@@ -1,0 +1,25 @@
+/* 
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CI_TEST_CONFIG_H
+#define CI_TEST_CONFIG_H
+
+#if defined(MBED_CONF_APP_DEBUG_MSG) && (MBED_CONF_APP_DEBUG_MSG != 0)
+#define DEBUG_PRINTF(...) do { printf(__VA_ARGS__); } while(0)
+#else
+#define DEBUG_PRINTF(...) {}
+#endif
+
+#endif

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -30,7 +30,8 @@
         "PWM_0": "D3",
         "PWM_1": "D5",
         "PWM_2": "D6",
-        "PWM_3": "D9"
+        "PWM_3": "D9",
+        "DEBUG_MSG": 0
     },
     "target_overrides": {
         "K64F": {


### PR DESCRIPTION
This header file is common, currently defines LOGGING. As we don't have
yet logging library, neither NDEBUG properly used in our profiles, I added a new
macro MBED_CONF_APP_DEBUG_MSG to enable/disable debug messages.

To enable logging, set DEBUG_MSG in the config to 1.

By default, the logging is disabled.

Tested with K64F with enabled and disabled, to see the the debug messages. I expect this will be cleaned-up once we get NDEBUG properly set in our profiles ( I sent one PR upstream to fix that).