### PR TITLE
Remove disable_irq for STM targets

### DIFF
--- a/TESTS/API/Pwm/Pwm.cpp
+++ b/TESTS/API/Pwm/Pwm.cpp
@@ -71,7 +71,9 @@ void PWM_Duty_slave(PinName pwm_out_pin, PinName int_in_pin, int period_in_ms, f
     duty_timer.start();
     pwm.write(duty_cycle_percent); // set duty cycle
     wait_ms(NUM_TESTS*period_in_ms);
+#if !defined(TARGET_STM)
     iin.disable_irq(); // This is here because otherwise it fails on some platforms
+#endif
     duty_timer.stop();
 
     float avgTime = (float)duty_running_count / NUM_TESTS;
@@ -136,7 +138,9 @@ void PWM_Period_Test()
     //Start Testing
     pwm.write(0.5f); // 50% duty cycle
     wait_ms(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
+#if !defined(TARGET_STM)
     iin.disable_irq(); // This is here because otherwise it fails on some platforms
+#endif
     int rc = rise_count; // grab the numbers to work with as the pwm may continue going
     int fc = fall_count;
 


### PR DESCRIPTION
These lines causes the PWM tests to freeze on STM targets. Without it the test is now ok.

Tested on some boards:

```
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case              | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Duty Cycle 100ms | 1      | 0      | OK     | 12.07              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Duty Cycle 30ms  | 1      | 0      | OK     | 3.65               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Frequency 100ms  | 1      | 0      | OK     | 10.08              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Frequency 10ms   | 1      | 0      | OK     | 10.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_0 Frequency 30ms   | 1      | 0      | OK     | 3.04               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Duty Cycle 100ms | 1      | 0      | OK     | 12.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Duty Cycle 30ms  | 1      | 0      | OK     | 3.64               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Frequency 10ms   | 1      | 0      | OK     | 10.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_1 Frequency 30ms   | 1      | 0      | OK     | 3.04               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Duty Cycle 100ms | 1      | 0      | OK     | 12.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Duty Cycle 30ms  | 1      | 0      | OK     | 3.65               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Frequency 10ms   | 1      | 0      | OK     | 10.05              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_2 Frequency 30ms   | 1      | 0      | OK     | 3.06               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Duty Cycle 100ms | 1      | 0      | OK     | 12.04              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Duty Cycle 30ms  | 1      | 0      | OK     | 3.63               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Frequency 100ms  | 1      | 0      | OK     | 10.04              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Frequency 10ms   | 1      | 0      | OK     | 10.04              |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | PWM_3 Frequency 30ms   | 1      | 0      | OK     | 3.05               |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-api-pwm | Pwm object definable   | 1      | 0      | OK     | 0.07               |
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case              | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Duty Cycle 100ms | 1      | 0      | OK     | 12.06              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Duty Cycle 10ms  | 1      | 0      | OK     | 1.23               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Duty Cycle 30ms  | 1      | 0      | OK     | 3.65               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Frequency 10ms   | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_0 Frequency 30ms   | 1      | 0      | OK     | 3.04               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Duty Cycle 100ms | 1      | 0      | OK     | 12.03              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Duty Cycle 30ms  | 1      | 0      | OK     | 3.64               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Frequency 10ms   | 1      | 0      | OK     | 10.03              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_1 Frequency 30ms   | 1      | 0      | OK     | 3.06               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Duty Cycle 100ms | 1      | 0      | OK     | 12.06              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Duty Cycle 10ms  | 1      | 0      | OK     | 1.25               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Duty Cycle 30ms  | 1      | 0      | OK     | 3.63               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Frequency 10ms   | 1      | 0      | OK     | 10.04              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_2 Frequency 30ms   | 1      | 0      | OK     | 3.04               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Duty Cycle 100ms | 1      | 0      | OK     | 12.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Duty Cycle 10ms  | 1      | 0      | OK     | 1.24               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Duty Cycle 30ms  | 1      | 0      | OK     | 3.64               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Frequency 100ms  | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Frequency 10ms   | 1      | 0      | OK     | 10.05              |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | PWM_3 Frequency 30ms   | 1      | 0      | OK     | 3.04               |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-pwm | Pwm object definable   | 1      | 0      | OK     | 0.07               |
+-------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
```

