### PR TITLE
TEST: SPI: CS is isually a DigitalOut

### DIFF
--- a/TESTS/API/SPI/SPI.cpp
+++ b/TESTS/API/SPI/SPI.cpp
@@ -50,7 +50,8 @@ void init_string()
 // Test object constructor / destructor
 void test_object()
 {
-    SPI(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK, MBED_CONF_APP_SPI_CS);
+    SPI(MBED_CONF_APP_SPI_MOSI, MBED_CONF_APP_SPI_MISO, MBED_CONF_APP_SPI_CLK);
+    DigitalOut cs(MBED_CONF_APP_SPI_CS);
     TEST_ASSERT_MESSAGE(true,"If the tests hangs here then there is a problem with the SPI Object"); // helpful debug message for if the test hangs
 }
 


### PR DESCRIPTION
In most SPI libs, CS is controlled as a GPIO, so as a DigitalOut. This
is also how this is done in the next SPI tests. So when testing the
instance creation, better to use this type as well.

If this is not done, tests would fail on boards where Hardware CS (NSS in pin STM32) is not muxed onto D10. This would require to define all the particular mapping of those boards, whereas using D10 as a DigitalOut is valid for any MBED board.