### PR TITLE
Remove printf call from interrupt context

### DIFF
--- a/TESTS/API/InterruptIn/InterruptIn.cpp
+++ b/TESTS/API/InterruptIn/InterruptIn.cpp
@@ -33,7 +33,6 @@ volatile bool result = false;
 void cbfn(void)
 {
     result = true;
-    DEBUG_PRINTF("\t**** Interrupt Triggered!\n");
 }
 
 // Template to check Falling edge and Rising edge interrupts.


### PR DESCRIPTION
With ARM compiler at least, if we enable DEBUG, the InterruptIn will fail
in timeout as the program would crash calling printf in the cbfn as this
happens in Interrupt context. Let's remove it