### PR TITLE
Adding checks for device support to assumption tests

### DIFF
--- a/TESTS/API/AnalogOut/AnalogOut.cpp
+++ b/TESTS/API/AnalogOut/AnalogOut.cpp
@@ -15,8 +15,6 @@
  */
 
 // check if AnalogOut is supported on this device
-
-#warning [NOT_SUPPORTED] AnalogOut not supported on this platform, add 'DEVICE_ANALOGOUT' definition to your platform. 
 #if !DEVICE_ANALOGOUT
   #error [NOT_SUPPORTED] AnalogOut not supported on this platform, add 'DEVICE_ANALOGOUT' definition to your platform. 
 #endif

--- a/TESTS/API/SPI/SPI.cpp
+++ b/TESTS/API/SPI/SPI.cpp
@@ -25,7 +25,7 @@
 
 // check if SPI is supported on this device
 #if !DEVICE_SPI
-    #error SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
+    #error [NOT_SUPPORTED] SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
 #endif
 
 using namespace utest::v1;

--- a/TESTS/assumptions/AnalogOut/AnalogOut.cpp
+++ b/TESTS/assumptions/AnalogOut/AnalogOut.cpp
@@ -1,3 +1,8 @@
+// check if AnalogOut is supported on this device
+#if !DEVICE_ANALOGOUT
+  #error [NOT_SUPPORTED] AnalogOut not supported on this platform, add 'DEVICE_ANALOGOUT' definition to your platform. 
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/assumptions/I2C/I2C.cpp
+++ b/TESTS/assumptions/I2C/I2C.cpp
@@ -1,3 +1,8 @@
+// check if I2C is supported on this device
+#if !DEVICE_I2C
+  #error [NOT_SUPPORTED] I2C not supported on this platform, add 'DEVICE_I2C' definition to your platform.
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/assumptions/Pwm/Pwm.cpp
+++ b/TESTS/assumptions/Pwm/Pwm.cpp
@@ -1,3 +1,7 @@
+#if !DEVICE_PWMOUT
+  #error [NOT_SUPPORTED] PWMOUT not supported on this platform, add 'DEVICE_PWMOUT' definition to your platform.
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/assumptions/PwmOut/PwmOut.cpp
+++ b/TESTS/assumptions/PwmOut/PwmOut.cpp
@@ -17,7 +17,7 @@
 //#error [NOT_SUPPORTED] PWM tests are still being written and validated, not for public use yet. 
 
 #if !DEVICE_PWMOUT
-    #error PWMOUT not supported on this platform, add 'DEVICE_PWMOUT' definition to your platform.
+    #error [NOT_SUPPORTED] PWMOUT not supported on this platform, add 'DEVICE_PWMOUT' definition to your platform.
 #endif
 
 #include "mbed.h"

--- a/TESTS/assumptions/SPI/SPI.cpp
+++ b/TESTS/assumptions/SPI/SPI.cpp
@@ -1,3 +1,8 @@
+// check if SPI is supported on this device
+#if !DEVICE_SPI
+    #error SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/assumptions/SPI/SPI.cpp
+++ b/TESTS/assumptions/SPI/SPI.cpp
@@ -1,6 +1,6 @@
 // check if SPI is supported on this device
 #if !DEVICE_SPI
-    #error SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
+    #error [NOT_SUPPORTED] SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
 #endif
 
 #include "mbed.h"


### PR DESCRIPTION
This adds the compile-time checks that allows builds to show up as "SKIPPED". For targets that don't support the given APIs, I've added the skip check so it's more apparent what is and what isn't being tested.