### PR TITLE
Fix logging interrupt safety

### DIFF
--- a/TESTS/API/InterruptIn/InterruptIn.cpp
+++ b/TESTS/API/InterruptIn/InterruptIn.cpp
@@ -33,6 +33,7 @@ volatile bool result = false;
 void cbfn(void)
 {
     result = true;
+    DEBUG_PRINTF("\t**** Interrupt Triggered!\n");
 }
 
 // Template to check Falling edge and Rising edge interrupts.

--- a/ci_test_config.h
+++ b/ci_test_config.h
@@ -16,8 +16,10 @@
 #ifndef CI_TEST_CONFIG_H
 #define CI_TEST_CONFIG_H
 
+#include "utest_serial.h"
+
 #if defined(MBED_CONF_APP_DEBUG_MSG) && (MBED_CONF_APP_DEBUG_MSG != 0)
-#define DEBUG_PRINTF(...) do { printf(__VA_ARGS__); } while(0)
+#define DEBUG_PRINTF(...) do { utest_printf(__VA_ARGS__); } while(0)
 #else
 #define DEBUG_PRINTF(...) {}
 #endif


### PR DESCRIPTION
Before this patch:

```
+----------+---------------+-----------------------+---------+--------------------+-------------+
| target   | platform_name | test suite            | result  | elapsed_time (sec) | copy_method |
+----------+---------------+-----------------------+---------+--------------------+-------------+
| K64F-ARM | K64F          | tests-api-interruptin | TIMEOUT | 51.1               | shell       |
+----------+---------------+-----------------------+---------+--------------------+-------------+
```

after 

```
+----------+---------------+-----------------------+--------+--------------------+-------------+
| target   | platform_name | test suite            | result | elapsed_time (sec) | copy_method |
+----------+---------------+-----------------------+--------+--------------------+-------------+
| K64F-ARM | K64F          | tests-api-interruptin | FAIL   | 15.66              | shell       |
+----------+---------------+-----------------------+--------+--------------------+-------------+
```

// fail as I did not connect 2 pins :-) but its obvious timeout is fixed

This is fixed via utest serial that is interrupt safe. Plus reverts the debug print in the interrupt routine as it works now.

cc @BlackstoneEngineering 

