### PR TITLE
i2ceeprom - use mbed_official fork

### DIFF
--- a/I2CEeprom.lib
+++ b/I2CEeprom.lib
@@ -1,1 +1,1 @@
-https://developer.mbed.org/users/rhourahane/code/I2CEeprom/#b23f5561266c
+https://developer.mbed.org/users/mbed_official/code/I2CEeprom/#973c4289c44c


### PR DESCRIPTION
To be able to fix/develop this fork.

Tested with k64f (using latest mbed-os master):

```
+--------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite    | test case                          | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.08               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | tests-api-i2c | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
+--------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
```

As the current one is not anymore in the development (PR ignored for some time).

cc @BlackstoneEngineering