### PR TITLE
Change pins configuration for disco F413 and L475

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -34,6 +34,13 @@
         "DEBUG_MSG": 0
     },
     "target_overrides": {
+        "DISCO_L475VG_IOT01A": {
+             "AOUT": "D7"
+        },
+        "DISCO_F413ZH": {
+             "AOUT": "A3",
+             "PWM_0": "D0"
+        },
         "NUCLEO_L476RG": {
              "AOUT": "A2"
         },


### PR DESCRIPTION
This PR changes the configuration of AOUT and PWM_0 pins for DISCO_F413ZH and DISCO_L475VG_IOT01A boards.