### PR TITLE
Change reference to D4 pin to user defined pin

### DIFF
--- a/TESTS/assumptions/PwmOut/PwmOut.cpp
+++ b/TESTS/assumptions/PwmOut/PwmOut.cpp
@@ -51,7 +51,7 @@ void pwm_interrupt_timer_test()
     Timer timer;
     PwmOut pwm(MBED_CONF_APP_PWM_0);
     InterruptIn x(MBED_CONF_APP_DIO_2);
-    InterruptIn y(D4);
+    InterruptIn y(MBED_CONF_APP_DIO_4);
     x.rise(cbfn_rise);
     x.fall(cbfn_fall);
     fall_count = 0;


### PR DESCRIPTION
This test fails to compile for any target that does not have a pin named D4. Change to the mbed_app.json defined pin. 