### PR TITLE
Check DEVICE_SPI before SDBlockDevice.h inclusion

### DIFF
--- a/TESTS/API/SPI/SPI.cpp
+++ b/TESTS/API/SPI/SPI.cpp
@@ -16,6 +16,11 @@
 
 // Waiting for public release to enable, currently there are problems with the SD driver
 
+// check if SPI is supported on this device
+#if !DEVICE_SPI
+    #error [NOT_SUPPORTED] SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
@@ -23,11 +28,6 @@
 #include "ci_test_config.h"
 #include "FATFileSystem.h"
 #include "SDBlockDevice.h"
-
-// check if SPI is supported on this device
-#if !DEVICE_SPI
-    #error [NOT_SUPPORTED] SPI is not supported on this platform, add 'DEVICE_SPI' definition to your platform.
-#endif
 
 using namespace utest::v1;
 


### PR DESCRIPTION
Non SPI support platform failed the test code build (by compile error)
without print [NOT_SUPPORTED]  message.
This PR fix the problem.