### PR TITLE
Level testing updates

### DIFF
--- a/TESTS/Level0/AnalogIn/AnalogIn.cpp
+++ b/TESTS/Level0/AnalogIn/AnalogIn.cpp
@@ -40,7 +40,7 @@ TestFramework test_framework;
 
 utest::v1::control_t test_level0_analogin(const size_t call_count) {
 	PinMap pin = test_framework.get_increment_pin(TestFramework::AnalogInput);
-	DEBUG_PRINTF("Running analog input constructor on pin %d\n", pin.pin);
+	DEBUG_PRINTF("Running analog input constructor on pin %#x\n", pin.pin);
   TEST_ASSERT_MESSAGE(pin.pin != NC, "Pin is NC");
 
 	AnalogIn ain(pin.pin);

--- a/TESTS/Level0/AnalogOut/AnalogOut.cpp
+++ b/TESTS/Level0/AnalogOut/AnalogOut.cpp
@@ -39,7 +39,7 @@ TestFramework test_framework;
 
 utest::v1::control_t test_level0_analogout(const size_t call_count) {
 	PinMap pin = test_framework.get_increment_pin(TestFramework::AnalogOutput);
-	DEBUG_PRINTF("Running analog output constructor on pin %d\n", pin.pin);
+	DEBUG_PRINTF("Running analog output constructor on pin %#x\n", pin.pin);
   TEST_ASSERT_MESSAGE(pin.pin != NC, "Pin is NC");
 
 	AnalogOut ain(pin.pin);

--- a/TESTS/Level0/BusInOut/BusInOut.cpp
+++ b/TESTS/Level0/BusInOut/BusInOut.cpp
@@ -53,7 +53,7 @@ utest::v1::control_t test_level0_businout(const size_t call_count) {
     }
 	}
 
-  DEBUG_PRINTF("Pins assigned to bus:\n  pin[0] = %d\n  pin[1] = %d\n  pin[2] = %d\n  pin[3] = %d\n  pin[4] = %d\n  pin[5] = %d\n  pin[6] = %d\n  pin[7] = %d\n  pin[8] = %d\n  pin[9] = %d\n  pin[10] = %d\n  pin[11] = %d\n  pin[12] = %d\n  pin[13] = %d\n  pin[14] = %d\n  pin[15] = %d\n",pins[0],pins[1],pins[2],pins[3],pins[4],pins[5],pins[6],pins[7],pins[8],pins[9],pins[10],pins[11],pins[12],pins[13],pins[14],pins[15]);
+  DEBUG_PRINTF("Pins assigned to bus:\n  pin[0] = %#x\n  pin[1] = %#x\n  pin[2] = %#x\n  pin[3] = %#x\n  pin[4] = %#x\n  pin[5] = %#x\n  pin[6] = %#x\n  pin[7] = %#x\n  pin[8] = %#x\n  pin[9] = %#x\n  pin[10] = %#x\n  pin[11] = %#x\n  pin[12] = %#x\n  pin[13] = %#x\n  pin[14] = %#x\n  pin[15] = %#x\n",pins[0],pins[1],pins[2],pins[3],pins[4],pins[5],pins[6],pins[7],pins[8],pins[9],pins[10],pins[11],pins[12],pins[13],pins[14],pins[15]);
 	
   // construct the bus with assigned pins
   BusInOut bio(pins[0],pins[1],pins[2],pins[3],pins[4],pins[5],pins[6],pins[7],pins[8],pins[9],pins[10],pins[11],pins[12],pins[13],pins[14],pins[15]);

--- a/TESTS/Level0/DigitalIO/DigitalIO.cpp
+++ b/TESTS/Level0/DigitalIO/DigitalIO.cpp
@@ -36,7 +36,7 @@ TestFramework test_framework;
 
 utest::v1::control_t test_level0_digitalio(const size_t call_count) {
 	PinMap pin = test_framework.get_increment_pin(TestFramework::DigitalIO);
-	DEBUG_PRINTF("Running digital io constructor on pin %d\n", pin.pin);
+	DEBUG_PRINTF("Running digital io constructor on pin %#x\n", pin.pin);
   TEST_ASSERT_MESSAGE(pin.pin != NC, "Pin is NC");
 
 	DigitalOut dout(pin.pin);

--- a/TESTS/Level0/I2C/I2C.cpp
+++ b/TESTS/Level0/I2C/I2C.cpp
@@ -39,7 +39,7 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 TestFramework test_framework;
 
 void construct_i2c(PinName sda, PinName scl) {
-	DEBUG_PRINTF("Running I2C Constructor on SDA pin %d and SCL pin %d\n", sda, scl);
+	DEBUG_PRINTF("Running I2C Constructor on SDA pin %#x and SCL pin %#x\n", sda, scl);
   TEST_ASSERT_MESSAGE(sda != NC, "SDA Pin is NC");
   TEST_ASSERT_MESSAGE(scl != NC, "SCL Pin is NC");
 

--- a/TESTS/Level0/Pwm/Pwm.cpp
+++ b/TESTS/Level0/Pwm/Pwm.cpp
@@ -40,7 +40,7 @@ TestFramework test_framework;
 
 utest::v1::control_t test_level0_pwm(const size_t call_count) {
 	PinMap pin = test_framework.get_increment_pin(TestFramework::PWM);
-	DEBUG_PRINTF("Running pwm constructor on pin %d\n", pin.pin);
+	DEBUG_PRINTF("Running PWM constructor on pin %#x\n", pin.pin);
   TEST_ASSERT_MESSAGE(pin.pin != NC, "pin is NC");
 
 	PwmOut pwm(pin.pin);

--- a/TESTS/Level0/SPI/SPI.cpp
+++ b/TESTS/Level0/SPI/SPI.cpp
@@ -39,7 +39,7 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 TestFramework test_framework;
 
 void construct_spi(PinName pin_clk, PinName pin_miso, PinName pin_mosi, PinName pin_cs) {
-	DEBUG_PRINTF("Running SPI constructor on CLK pin %d, MISO pin %d, MOSI pin %d, and CS pin %d\n", pin_clk, pin_miso, pin_mosi, pin_cs);
+	DEBUG_PRINTF("Running SPI constructor on CLK pin %#x, MISO pin %#x, MOSI pin %#x, and CS pin %#x\n", pin_clk, pin_miso, pin_mosi, pin_cs);
   TEST_ASSERT_MESSAGE(pin_clk != NC, "SPI CLK pin is NC");
   TEST_ASSERT_MESSAGE(pin_mosi != NC, "SPI MOSI Pin is NC");
   TEST_ASSERT_MESSAGE(pin_miso != NC, "SPI MISO Pin is NC");

--- a/TESTS/Level1/AnalogIn/AnalogIn.cpp
+++ b/TESTS/Level1/AnalogIn/AnalogIn.cpp
@@ -76,7 +76,6 @@ void test_analogin_execute(PinName pin, float tolerance, int iterations) {
 
 	    // Read the new value to make sure the voltage increased
 	    new_value = ain.read();
-      DEBUG_PRINTF("new_value on bus = %d\n", new_value);
 	    TEST_ASSERT_MESSAGE(new_value > prev_value,"Analog Input did not increment. Check that you have assigned valid pins in mbed_app.json file")
 
 	    // Repeat the read multiple times to verify the output is not fluctuating

--- a/TESTS/Level1/AnalogIn/AnalogIn.cpp
+++ b/TESTS/Level1/AnalogIn/AnalogIn.cpp
@@ -39,7 +39,7 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 TestFramework test_framework;
 
 void test_analogin_execute(PinName pin, float tolerance, int iterations) {
-	DEBUG_PRINTF("Running analog input range test on pin %d\n", pin);
+	DEBUG_PRINTF("Running analog input range test on pin %#x\n", pin);
   TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
   // Find all pins on the resistor ladder that are not the current pin
@@ -51,7 +51,7 @@ void test_analogin_execute(PinName pin, float tolerance, int iterations) {
   BusInOut outputs(resistor_ladder_pins[0],resistor_ladder_pins[1],resistor_ladder_pins[2],resistor_ladder_pins[3],resistor_ladder_pins[4]);
 	outputs.output();
 
-  DEBUG_PRINTF("Creating a resistive ladder bus with the following pins:\n  pin[0] = %d\n  pin[1] = %d\n  pin[2] = %d\n  pin[3] = %d\n  pin[4] = %d\n", resistor_ladder_pins[0],resistor_ladder_pins[1],resistor_ladder_pins[2],resistor_ladder_pins[3],resistor_ladder_pins[4]);
+  DEBUG_PRINTF("Creating a resistive ladder bus with the following pins:\n  pin[0] = %#x\n  pin[1] = %#x\n  pin[2] = %#x\n  pin[3] = %#x\n  pin[4] = %#x\n", resistor_ladder_pins[0],resistor_ladder_pins[1],resistor_ladder_pins[2],resistor_ladder_pins[3],resistor_ladder_pins[4]);
 
   // construct designated analogIn pin
 	AnalogIn ain(pin);

--- a/TESTS/Level1/AnalogOut/AnalogOut.cpp
+++ b/TESTS/Level1/AnalogOut/AnalogOut.cpp
@@ -39,7 +39,7 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 TestFramework test_framework;
 
 void test_analogout_execute(PinName pin, float tolerance, int iterations){
-	DEBUG_PRINTF("Running analog output range test on pin %d\n", pin);
+	DEBUG_PRINTF("Running analog output range test on pin %#x\n", pin);
   TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
   // Find all pins on the resistor ladder that are not the current pin

--- a/TESTS/Level1/AnalogOut/AnalogOut.cpp
+++ b/TESTS/Level1/AnalogOut/AnalogOut.cpp
@@ -38,25 +38,24 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 // Initialize a test framework object
 TestFramework test_framework;
 
-void test_analogout_execute(PinName pin, float tolerance, int iterations) {
+void test_analogout_execute(PinName pin, float tolerance, int iterations){
 	DEBUG_PRINTF("Running analog output range test on pin %d\n", pin);
-    TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
+  TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
-    // Find all pins on the resistor ladder that are not the current pin
+  // Find all pins on the resistor ladder that are not the current pin
 	std::vector<PinName> resistor_ladder_pins = TestFramework::find_resistor_ladder_pins(pin);
-	if (resistor_ladder_pins.size() < 5)
+  if (resistor_ladder_pins.size() < 5){
 		TEST_ASSERT_MESSAGE(false, "Error finding the resistor ladder pins");
+  }
 
-	AnalogIn ain(resistor_ladder_pins[0]);
-
+	AnalogIn ain(resistor_ladder_pins[0]); 
 	// Repeat to guarentee consistency
-    for (unsigned int i=0; i<iterations; i++) {
-
-	    float input = 0.0f;
+  for (unsigned int i=0; i<iterations; i++){
+	  float input = 0.0f;
 		AnalogOut aout(pin);
 
-		// Itereate at 100mV increments
-		for (float i=0.0f; i<=1.0f; i+=0.1f) {
+    // Itereate at 100mV increments
+		for (float i=0.0f; i<=1.0f; i+=0.1f){
 			aout = i;
 			input = ain.read();
 			// Verify input matches expected output within a certain tolerance

--- a/TESTS/Level1/BusInOut/BusInOut.cpp
+++ b/TESTS/Level1/BusInOut/BusInOut.cpp
@@ -38,7 +38,7 @@ void test_busio_execute(PinName pin, float tolerance, int iterations) {
   TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
   PinName pin_pair = TestFramework::find_pin_pair(pin);
-  DEBUG_PRINTF("Running BusIO test on pin %d and its pin-pair %d", pin, pin_pair);
+  DEBUG_PRINTF("Running BusIO test on pin %#x and its pin-pair %#x", pin, pin_pair);
 
   BusInOut bio1(pin);
   BusInOut bio2(pin_pair);

--- a/TESTS/Level1/BusInOut/BusInOut.cpp
+++ b/TESTS/Level1/BusInOut/BusInOut.cpp
@@ -34,24 +34,25 @@ std::vector<unsigned int> TestFramework::pin_iterators(TS_NC);
 // Initialize a test framework object
 TestFramework test_framework;
 
-void test_busio_execute(PinName pin, float tolerance, int iterations) {
-	DEBUG_PRINTF("Running analog input range test on pin %d\n", pin);
-    TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
+void test_busio_execute(PinName pin, float tolerance, int iterations) {	
+  TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
-    PinName pin_pair = TestFramework::find_pin_pair(pin);
-    BusInOut bio1(pin);
-    BusInOut bio2(pin_pair);
+  PinName pin_pair = TestFramework::find_pin_pair(pin);
+  DEBUG_PRINTF("Running BusIO test on pin %d and its pin-pair %d", pin, pin_pair);
 
-    bio1.output();
-    bio2.input();
-    bio1 = 0;
-    TEST_ASSERT_MESSAGE(bio2.read()==0, "Value read on bus does not equal value written.");
-    bio1 = 1;
-    TEST_ASSERT_MESSAGE(bio2.read()==1, "Value read on bus does not equal value written.");
+  BusInOut bio1(pin);
+  BusInOut bio2(pin_pair);
+
+  bio1.output();
+  bio2.input();
+  bio1 = 0;
+  TEST_ASSERT_MESSAGE(bio2.read()==0, "Value read on bus does not equal value written.");
+  bio1 = 1;
+  TEST_ASSERT_MESSAGE(bio2.read()==1, "Value read on bus does not equal value written.");
 }
 
 utest::v1::control_t test_level1_busio(const size_t call_count) {
-	return TestFramework::test_level2_framework(TestFramework::BusIO, TestFramework::CITS_DigitalIO, &test_busio_execute, 0.05, 10);
+	return TestFramework::test_level1_framework(TestFramework::BusIO, TestFramework::CITS_DigitalIO, &test_busio_execute, 0.05, 10);
 }
 
 Case cases[] = {
@@ -61,5 +62,5 @@ Case cases[] = {
 int main() {
 	// Formulate a specification and run the tests based on the Case array
 	Specification specification(TestFramework::test_setup<30>, cases);
-    return !Harness::run(specification);
+  return !Harness::run(specification);
 }

--- a/TESTS/Level1/DigitalIO/DigitalIO.cpp
+++ b/TESTS/Level1/DigitalIO/DigitalIO.cpp
@@ -42,18 +42,19 @@ void dio_toggled(void) {
 }
 
 void test_digitalio_execute(PinName pin, float tolerance, int iterations) {
-	DEBUG_PRINTF("Running digital io test on pin %d\n", pin);
-    TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
+  TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
-    PinName pinpair = TestFramework::find_pin_pair(pin);
-    DigitalOut dout(pinpair);
-    DigitalIn din(pin);
+  PinName pinpair = TestFramework::find_pin_pair(pin);
+  DEBUG_PRINTF("Running digital io test on pin %#x and its pin-pair %#x", pin, pin_pair);
 
-    // Verify Digital Input and Output can occur on the same pin
-    dout = 0;
-    TEST_ASSERT_MESSAGE(0 == din.read(),"Expected value to be 0, read value was not zero");
-    dout = 1;
-    TEST_ASSERT_MESSAGE(1 == din.read(),"Expected value to be 1, read value was not one");
+  DigitalOut dout(pinpair);
+  DigitalIn din(pin);
+
+  // Verify Digital Input and Output can occur on the same pin
+  dout = 0;
+  TEST_ASSERT_MESSAGE(0 == din.read(),"Expected value to be 0, read value was not zero");
+  dout = 1;
+  TEST_ASSERT_MESSAGE(1 == din.read(),"Expected value to be 1, read value was not one");
 }
 
 utest::v1::control_t test_level1_digitalio(const size_t call_count) {
@@ -67,5 +68,5 @@ Case cases[] = {
 int main() {
 	// Formulate a specification and run the tests based on the Case array
 	Specification specification(TestFramework::test_setup<30>, cases);
-    return !Harness::run(specification);
+  return !Harness::run(specification);
 }

--- a/TESTS/Level1/DigitalIO/DigitalIO.cpp
+++ b/TESTS/Level1/DigitalIO/DigitalIO.cpp
@@ -45,7 +45,7 @@ void test_digitalio_execute(PinName pin, float tolerance, int iterations) {
   TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
   PinName pinpair = TestFramework::find_pin_pair(pin);
-  DEBUG_PRINTF("Running digital io test on pin %#x and its pin-pair %#x", pin, pin_pair);
+  DEBUG_PRINTF("Running digital io test on pin %#x and its pin-pair %#x", pin, pinpair);
 
   DigitalOut dout(pinpair);
   DigitalIn din(pin);

--- a/TESTS/Level1/I2C/I2C.cpp
+++ b/TESTS/Level1/I2C/I2C.cpp
@@ -53,7 +53,7 @@ utest::v1::control_t test_level1_i2c(const size_t call_count) {
 		return utest::v1::CaseNext;
 	}
 
-	DEBUG_PRINTF("Running I2C constructor on SDA pin %d and SCL pin %d\n", pin_sda, pin_scl);
+	DEBUG_PRINTF("Running I2C constructor on SDA pin %#x and SCL pin %#x\n", pin_sda, pin_scl);
   TEST_ASSERT_MESSAGE(pin_sda != NC, "SDA Pin is NC");
   TEST_ASSERT_MESSAGE(pin_scl != NC, "SCL Pin is NC");
 
@@ -61,9 +61,9 @@ utest::v1::control_t test_level1_i2c(const size_t call_count) {
 
 	// Generate a random string
   char test_string[128] = {0};
-  for (int i=0; i<iterations; i++) 
+  for (int i=0; i<iterations; i++){ 
   	test_string[i] = DEADBEEF[i%8];
-
+  }
   char initial_read[128] = {0};
   char should_be_null[128] = {0};
   char read_data[128] = {0};

--- a/TESTS/Level1/Pwm/Pwm.cpp
+++ b/TESTS/Level1/Pwm/Pwm.cpp
@@ -46,65 +46,66 @@ int duty_count;
 
 // Callback for a PWM rising edge
 void callback_pwm_rise(void) {
-    rise_count++;
-    last_rise_time = timer.read_ms();
+  rise_count++;
+  last_rise_time = timer.read_ms();
 }
 
 // Callback for a PWM falling edge
 void callback_pwm_fall(void) {
-    fall_count++;
-    if (last_rise_time != 0)
-        duty_count = duty_count + (timer.read_ms() - last_rise_time);
+  fall_count++;
+  if (last_rise_time != 0){
+    duty_count = duty_count + (timer.read_ms() - last_rise_time);
+  }
 }
 
 void test_pwm_execute(PinName pin, float dutycycle, int period) {
-	DEBUG_PRINTF("Running pwm test on pin %d\n", pin);
-    TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
+	DEBUG_PRINTF("Running pwm test on pin %#x\n", pin);
+  TEST_ASSERT_MESSAGE(pin != NC, "Pin is NC");
 
-    // Initialize
-    float tolerance = 0.05;
-    int iterations = 20;
-    float calculated_percent = iterations * tolerance;
-    if (calculated_percent < 1) calculated_percent = 1.0f;
-    fall_count = 0;
-    rise_count = 0;
-    last_rise_time = 0;
-    duty_count = 0;
+  // Initialize
+  float tolerance = 0.05;
+  int iterations = 20;
+  float calculated_percent = iterations * tolerance;
+  if (calculated_percent < 1) calculated_percent = 1.0f;
+  fall_count = 0;
+  rise_count = 0;
+  last_rise_time = 0;
+  duty_count = 0;
 
-    PwmOut pwm(pin);
-    timer.reset();
-    InterruptIn iin(TestFramework::find_pin_pair(pin));
-    iin.rise(callback_pwm_rise);
-    iin.fall(callback_pwm_fall);
+  PwmOut pwm(pin);
+  timer.reset();
+  InterruptIn iin(TestFramework::find_pin_pair(pin));
+  iin.rise(callback_pwm_rise);
+  iin.fall(callback_pwm_fall);
 
-    // Set the period
-    DEBUG_PRINTF("Period set to: %f, duty cycle set to: %f\n", (float)period/1000, dutycycle);
-    pwm.period((float)period/1000);
-    pwm.write(0);
-    DEBUG_PRINTF("Waiting for %dms\n", iterations * period);
+  // Set the period
+  DEBUG_PRINTF("Period set to: %f, duty cycle set to: %f\n", (float)period/1000, dutycycle);
+  pwm.period((float)period/1000);
+  pwm.write(0);
+  DEBUG_PRINTF("Waiting for %dms\n", iterations * period);
 
-    // Start the timer, write the duty cycle, and wait for completion
-    timer.start();
-    pwm.write(dutycycle);
-    wait_ms(iterations * period);
+  // Start the timer, write the duty cycle, and wait for completion
+  timer.start();
+  pwm.write(dutycycle);
+  wait_ms(iterations * period);
 
-    // Stop the timer, reset the IRQ for interrupts (cause it may not work on some platforms) and clear the PWM duty cycle
-    pwm.write(0);
-    iin.disable_irq();
-    timer.stop();
+  // Stop the timer, reset the IRQ for interrupts (cause it may not work on some platforms) and clear the PWM duty cycle
+  pwm.write(0);
+  iin.disable_irq();
+  timer.stop();
 
-    // Run post calculations for verification
-    int rc = rise_count;
-    int fc = fall_count;
-    float avgTime = (float)duty_count / iterations;
-    float expectedTime = (float)period * dutycycle;
-    DEBUG_PRINTF("Expected time: %f, Avg Time: %f\n", expectedTime, avgTime);
-    DEBUG_PRINTF("rise count = %d, fall count = %d, expected count = %d\n", rc, fc, iterations);
-    TEST_ASSERT_MESSAGE( std::abs(rc-fc) <= calculated_percent, "There was more than a specific variance in number of rise vs fall cycles");
-    TEST_ASSERT_MESSAGE( std::abs(iterations - rc) <= calculated_percent, "There was more than a specific variance in number of rise cycles seen and number expected.");
-    TEST_ASSERT_MESSAGE( std::abs(iterations - fc) <= calculated_percent, "There was more than a specific variance in number of fall cycles seen and number expected.");
-    // @TODO The following assert is a good check to have (comparing times) but fails on most platforms. Need to come up with a better way to do this test
-    // TEST_ASSERT_MESSAGE( std::abs(expectedTime - avgTime) <= calculated_percent,"Greater than a specific variance between expected and measured duty cycle");
+  // Run post calculations for verification
+  int rc = rise_count;
+  int fc = fall_count;
+  float avgTime = (float)duty_count / iterations;
+  float expectedTime = (float)period * dutycycle;
+  DEBUG_PRINTF("Expected time: %f, Avg Time: %f\n", expectedTime, avgTime);
+  DEBUG_PRINTF("rise count = %d, fall count = %d, expected count = %d\n", rc, fc, iterations);
+  TEST_ASSERT_MESSAGE( std::abs(rc-fc) <= calculated_percent, "There was more than a specific variance in number of rise vs fall cycles");
+  TEST_ASSERT_MESSAGE( std::abs(iterations - rc) <= calculated_percent, "There was more than a specific variance in number of rise cycles seen and number expected.");
+  TEST_ASSERT_MESSAGE( std::abs(iterations - fc) <= calculated_percent, "There was more than a specific variance in number of fall cycles seen and number expected.");
+  // @TODO The following assert is a good check to have (comparing times) but fails on most platforms. Need to come up with a better way to do this test
+  // TEST_ASSERT_MESSAGE( std::abs(expectedTime - avgTime) <= calculated_percent,"Greater than a specific variance between expected and measured duty cycle");
 }
 
 template <int dutycycle, int period> 
@@ -124,5 +125,5 @@ Case cases[] = {
 int main() {
 	// Formulate a specification and run the tests based on the Case array
 	Specification specification(TestFramework::test_setup<30>, cases);
-    return !Harness::run(specification);
+  return !Harness::run(specification);
 }

--- a/TESTS/Level1/SPI/SPI.cpp
+++ b/TESTS/Level1/SPI/SPI.cpp
@@ -55,7 +55,7 @@ utest::v1::control_t test_level1_spi(const size_t call_count) {
 		return utest::v1::CaseNext;
 	}
 
-	DEBUG_PRINTF("Running SPI constructor on CLK pin %d, MISO pin %d, MOSI pin %d, and CS pin %d\n", pin_clk, pin_miso, pin_mosi, pin_cs);
+	DEBUG_PRINTF("Running SPI constructor on CLK pin %#x, MISO pin %#x, MOSI pin %#x, and CS pin %#x\n", pin_clk, pin_miso, pin_mosi, pin_cs);
   TEST_ASSERT_MESSAGE(pin_clk != NC, "SPI CLK pin is NC");
   TEST_ASSERT_MESSAGE(pin_mosi != NC, "SPI MOSI Pin is NC");
   TEST_ASSERT_MESSAGE(pin_miso != NC, "SPI MISO Pin is NC");

--- a/TestFramework.cpp
+++ b/TestFramework.cpp
@@ -21,25 +21,40 @@
 //								Initialization								                             //
 /////////////////////////////////////////////////////////////////////////////*/
 TestFramework::TestFramework() {
-	map_pins(PinMap_ADC, AnalogInput);
-	map_pins(PinMap_DAC, AnalogOutput);
-	map_pins(PinMap_PWM, DigitalIO);
-	map_pins(PinMap_ADC, DigitalIO);
-	  // map_pins(PinMap_DAC, DigitalIO); grabbing pin number from PeripheralPins.c, instead of the pin translation from mbed_app.json
-	map_pins(PinMap_I2C_SDA, DigitalIO);
-	map_pins(PinMap_I2C_SCL, DigitalIO);
-	map_pins(PinMap_SPI_SCLK, DigitalIO);
-	map_pins(PinMap_SPI_MOSI, DigitalIO);
-	map_pins(PinMap_SPI_MISO, DigitalIO);
-	map_pins(PinMap_SPI_SSEL, DigitalIO);
+  #ifdef DEVICE_ANALOGIN
+	  map_pins(PinMap_ADC, AnalogInput);
+    map_pins(PinMap_ADC, DigitalIO);
+  #endif  // DEVICE_ANALOGIN
+
+  #ifdef DEVICE_ANALOGOUT
+    map_pins(PinMap_DAC, AnalogOutput);
+  	// map_pins(PinMap_DAC, DigitalIO); grabbing pin number from PeripheralPins.c, instead of the pin translation from mbed_app.json
+  #endif  // DEVICE_ANALOGOUT
+
+  #ifdef DEVICE_I2C
+	  map_pins(PinMap_I2C_SDA, DigitalIO);
+	  map_pins(PinMap_I2C_SCL, DigitalIO);
+    map_pins(PinMap_I2C_SDA, I2C_SDA);
+	  map_pins(PinMap_I2C_SCL, I2C_SCL);
+  #endif  // DEVICE_I2C
+
+  #ifdef DEVICE_PWMOUT
+    map_pins(PinMap_PWM, DigitalIO);
+	  map_pins(PinMap_PWM, PWM);
+  #endif  // DEVICE_PWMOUT
+
+  #ifdef DEVICE_SPI
+    map_pins(PinMap_SPI_SCLK, DigitalIO);
+	  map_pins(PinMap_SPI_MOSI, DigitalIO);
+	  map_pins(PinMap_SPI_MISO, DigitalIO);
+	  map_pins(PinMap_SPI_SSEL, DigitalIO);
+    map_pins(PinMap_SPI_SCLK, SPI_CLK);
+	  map_pins(PinMap_SPI_MOSI, SPI_MOSI);
+	  map_pins(PinMap_SPI_MISO, SPI_MISO);
+	  map_pins(PinMap_SPI_SSEL, SPI_CS);
+  #endif  // DEVICE_SPI
+
 	pinout[BusIO] = pinout[DigitalIO];
-	map_pins(PinMap_PWM, PWM);
-	map_pins(PinMap_I2C_SDA, I2C_SDA);
-	map_pins(PinMap_I2C_SCL, I2C_SCL);
-	map_pins(PinMap_SPI_SCLK, SPI_CLK);
-	map_pins(PinMap_SPI_MOSI, SPI_MOSI);
-	map_pins(PinMap_SPI_MISO, SPI_MISO);
-	map_pins(PinMap_SPI_SSEL, SPI_CS);
 	setup_cits_pins();
 }
 

--- a/TestFramework.cpp
+++ b/TestFramework.cpp
@@ -102,9 +102,16 @@ void TestFramework::map_pins(const PinMap pinmap[], Type pintype) {
 			if (pinout[pintype][j].pin == pinmap[i].pin)
 				alreadyExists = true;
 		}
-    // if pin is not already in pinout and is not already assigned to USB_UART, then add to pinout
-		if ((!alreadyExists) && (pinmap[i].pin != USBTX) && (pinmap[i].pin != USBRX)) {
-			pinout[pintype].push_back(pinmap[i]);
+    // push each valid pin onto the pinmap once for each pin. 
+    #ifdef TARGET_STM
+    // if testing on STM boards, do not add ADC internal channels, USBTX, and USBRX pins
+    if ((!alreadyExists) && (pinmap[i].pin != USBTX) && (pinmap[i].pin != USBRX) && (pinmap[i].pin != ADC_TEMP) && (pinmap[i].pin != ADC_VREF) && (pinmap[i].pin != ADC_VBAT)){ 
+    
+    #else // else if not testing on STM boards
+    // do not add USBTX and USBRX pins
+		if ((!alreadyExists) && (pinmap[i].pin != USBTX) && (pinmap[i].pin != USBRX)){
+    #endif // TARGET_STM
+			pinout[pintype].push_back(pinmap[i]); // add pin to end of pinmap
 		}
 		i++;
 	}

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -31,7 +31,7 @@
         "PWM_1": "D5",
         "PWM_2": "D6",
         "PWM_3": "D9",
-        "DEBUG_MSG": 1
+        "DEBUG_MSG": 0
     },
     "target_overrides": {
         "DISCO_L475VG_IOT01A": {


### PR DESCRIPTION
* Added ifdef guards to TestFramwork.cpp, so that tests can compile with boards that do not have all the PinMaps defines.

* Fixed bug in Level1/BusInOut where it was calling Level2 framework instead of Level1.

* formatted code for consistency/