### PR TITLE
tests-api-businout : increase TIMEOUT

### DIFF
--- a/TESTS/API/BusInOut/BusInOut.cpp
+++ b/TESTS/API/BusInOut/BusInOut.cpp
@@ -98,7 +98,7 @@ void businout_bidirectional_test(){
 
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     // Setup Greentea using a reasonable timeout in seconds
-    GREENTEA_SETUP(30, "default_auto");
+    GREENTEA_SETUP(40, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 


### PR DESCRIPTION
Test with NUCLEO_L476RG-GCC_ARM : 30s is not long enough,
it seems that 40s is OK
