### PR TITLE
Don't execute multi thread test cases for small RAM targets

### DIFF
--- a/TESTS/concurrent/Comms/Comms.cpp
+++ b/TESTS/concurrent/Comms/Comms.cpp
@@ -204,7 +204,9 @@ utest::v1::status_t greentea_failure_handler(const Case *const source, const fai
 // Test cases
 Case cases[] = {
     Case("Concurrent testing of I2C and SPI in a single thread",test_single_thread,greentea_failure_handler),
+#if !MBED_CONF_APP_SINGLE_THREAD_ONLY
     Case("Concurrent testing of I2C and SPI in multiple threads",test_multiple_threads,greentea_failure_handler),
+#endif /* MBED_CONF_APP_SINGLE_THREAD_ONLY */
 };
 
 

--- a/TESTS/concurrent/Mixed/Mixed.cpp
+++ b/TESTS/concurrent/Mixed/Mixed.cpp
@@ -318,7 +318,9 @@ utest::v1::status_t greentea_failure_handler(const Case *const source, const fai
 // Test cases
 Case cases[] = {
     Case("Concurrent testing of Comms and GPIO in a single thread",test_single_thread,greentea_failure_handler),
+#if !MBED_CONF_APP_SINGLE_THREAD_ONLY
     Case("Concurrent testing of Comms and GPIO in multiple threads",test_multiple_threads,greentea_failure_handler),
+#endif /* MBED_CONF_APP_SINGLE_THREAD_ONLY */
 };
 
 

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "SINGLE_THREAD_ONLY": "0",
         "UART_RX": "D0",
         "UART_TX": "D1",
         "DIO_0": "D0",
@@ -51,6 +52,9 @@
              "PWM_0": "D2",
              "PWM_2": "D7",
              "AOUT": "A2"
+        },
+        "NUCLEO_F103RB": {
+             "SINGLE_THREAD_ONLY": "1"
         },
         "NUCLEO_F302R8": {
              "AOUT": "A2"


### PR DESCRIPTION
This is a proposition to make tests OK even for small RAM targets.

Thx
