### PR TITLE
Make top level repo ignore sources deployed from libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+I2CEeprom
+LM75B
+mbed-os
+SDDriver
+
+
 # Ignore list for Eagle, a PCB layout tool
 
 # Backup files


### PR DESCRIPTION
After 'mbed deploy', 'mbed compile', or 'mbed test' the source files for libraries (EEPROM, SD Card, Temp Sensor) are downloaded from their respective urls in the .lib files.  These files are un-tracked by git so they show up as a bunch of uncommitted changes.  Would be nice for git to just ignore them.  