### PR TITLE
Removing SDDriver

### DIFF
--- a/SDDriver.lib
+++ b/SDDriver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sd-driver/#c7dba873638863a28d47348f1ba41db9c5da31a0


### PR DESCRIPTION
Mbed OS now has block device driver code. No need for carrying
this as a library. This change will resolve linking errors
as seen here

```
Built with: 
mbed test -n tests-api-spi

Linking Error:
BUILD/tests/K64F/GCC_ARM/mbed-os/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.o: In function `mbed::SPI::~SPI()':
C:\mbed-cli\ci-test-shield.git/./mbed-os/platform/Callback.h:906: multiple definition of `SDBlockDevice::deinit()'
BUILD/tests/K64F/GCC_ARM/SDDriver/features/filesystem/sd/SDBlockDevice.o:C:\mbed-cli\ci-test-shield.git/.\SDDriver\features\filesystem\sd/SDBlockDevice.cpp:260: first defined here
BUILD/tests/K64F/GCC_ARM/mbed-os/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.o: In function `BlockDevice::sync()':...

```