### PR TITLE
Add test for I2C read single byte transactions for temperature sensor

### DIFF
--- a/LM75B.lib
+++ b/LM75B.lib
@@ -1,1 +1,0 @@
-https://developer.mbed.org/users/neilt6/code/LM75B/#7ac462ba84ac

--- a/LM75B/LM75B.cpp
+++ b/LM75B/LM75B.cpp
@@ -1,0 +1,286 @@
+/* LM75B Driver Library
+ * Copyright (c) 2013 Neil Thiessen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LM75B.h"
+
+LM75B::LM75B(PinName sda, PinName scl, Address addr, int hz) : m_I2C(sda, scl), m_ADDR((int)addr)
+{
+    //Set the I2C bus frequency
+    m_I2C.frequency(hz);
+}
+
+bool LM75B::open()
+{
+    //Probe for the LM75B using a Zero Length Transfer
+    if (!m_I2C.write(m_ADDR, NULL, 0)) {
+        //Return success
+        return true;
+    } else {
+        //Return failure
+        return false;
+    }
+}
+
+LM75B::PowerMode LM75B::powerMode()
+{
+    //Read the 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Return the status of the SHUTDOWN bit
+    if (value & (1 << 0))
+        return POWER_SHUTDOWN;
+    else
+        return POWER_NORMAL;
+}
+
+void LM75B::powerMode(PowerMode mode)
+{
+    //Read the current 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Set or clear the SHUTDOWN bit
+    if (mode == POWER_SHUTDOWN)
+        value |= (1 << 0);
+    else
+        value &= ~(1 << 0);
+
+    //Write the value back out
+    write8(REG_CONF, value);
+}
+
+LM75B::OSMode LM75B::osMode()
+{
+    //Read the 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Return the status of the OS_COMP_INT bit
+    if (value & (1 << 1))
+        return OS_INTERRUPT;
+    else
+        return OS_COMPARATOR;
+}
+
+void LM75B::osMode(OSMode mode)
+{
+    //Read the current 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Set or clear the OS_COMP_INT bit
+    if (mode == OS_INTERRUPT)
+        value |= (1 << 1);
+    else
+        value &= ~(1 << 1);
+
+    //Write the value back out
+    write8(REG_CONF, value);
+}
+
+LM75B::OSPolarity LM75B::osPolarity()
+{
+    //Read the 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Return the status of the OS_POL bit
+    if (value & (1 << 2))
+        return OS_ACTIVE_HIGH;
+    else
+        return OS_ACTIVE_LOW;
+}
+
+void LM75B::osPolarity(OSPolarity polarity)
+{
+    //Read the current 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Set or clear the OS_POL bit
+    if (polarity == OS_ACTIVE_HIGH)
+        value |= (1 << 2);
+    else
+        value &= ~(1 << 2);
+
+    //Write the value back out
+    write8(REG_CONF, value);
+}
+
+LM75B::OSFaultQueue LM75B::osFaultQueue()
+{
+    //Read the 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Return the status of the OS_F_QUE bits
+    if ((value & (1 << 3)) && (value & (1 << 4)))
+        return OS_FAULT_QUEUE_6;
+    else if (!(value & (1 << 3)) && (value & (1 << 4)))
+        return OS_FAULT_QUEUE_4;
+    else if ((value & (1 << 3)) && !(value & (1 << 4)))
+        return OS_FAULT_QUEUE_2;
+    else
+        return OS_FAULT_QUEUE_1;
+}
+
+void LM75B::osFaultQueue(OSFaultQueue queue)
+{
+    //Read the current 8-bit register value
+    char value = read8(REG_CONF);
+
+    //Clear the old OS_F_QUE bits
+    value &= ~(3 << 3);
+
+    //Set the new OS_F_QUE bits
+    if (queue == OS_FAULT_QUEUE_2)
+        value |= (1 << 3);
+    else if (queue == OS_FAULT_QUEUE_4)
+        value |= (2 << 3);
+    else if (queue == OS_FAULT_QUEUE_6)
+        value |= (3 << 3);
+
+    //Write the value back out
+    write8(REG_CONF, value);
+}
+
+float LM75B::alertTemp()
+{
+    //Use the 9-bit helper to read the TOS register
+    return readAlertTempHelper(REG_TOS);
+}
+
+void LM75B::alertTemp(float temp)
+{
+    //Use the 9-bit helper to write to the TOS register
+    return writeAlertTempHelper(REG_TOS, temp);
+}
+
+float LM75B::alertHyst()
+{
+    //Use the 9-bit helper to read the THYST register
+    return readAlertTempHelper(REG_THYST);
+}
+
+void LM75B::alertHyst(float temp)
+{
+    //Use the 9-bit helper to write to the THYST register
+    return writeAlertTempHelper(REG_THYST, temp);
+}
+
+float LM75B::temp()
+{
+    //Signed return value
+    short value;
+
+    //Read the 11-bit raw temperature value
+    value = read16(REG_TEMP) >> 5;
+
+    //Sign extend negative numbers
+    if (value & (1 << 10))
+        value |= 0xFC00;
+
+    //Return the temperature in °C
+    return value * 0.125;
+}
+
+#ifdef MBED_OPERATORS
+LM75B::operator float()
+{
+    //Return the current temperature reading
+    return temp();
+}
+#endif
+
+char LM75B::read8(char reg)
+{
+    //Select the register
+    m_I2C.write(m_ADDR, &reg, 1, true);
+
+    //Read the 8-bit register
+    m_I2C.read(m_ADDR, &reg, 1);
+
+    //Return the byte
+    return reg;
+}
+
+void LM75B::write8(char reg, char data)
+{
+    //Create a temporary buffer
+    char buff[2];
+
+    //Load the register address and 8-bit data
+    buff[0] = reg;
+    buff[1] = data;
+
+    //Write the data
+    m_I2C.write(m_ADDR, buff, 2);
+}
+
+unsigned short LM75B::read16(char reg)
+{
+    //Create a temporary buffer
+    char buff[2];
+
+    //Select the register
+    m_I2C.write(m_ADDR, &reg, 1, true);
+
+    //Read the 16-bit register
+    m_I2C.read(m_ADDR, buff, 2);
+
+    //Return the combined 16-bit value
+    return (buff[0] << 8) | buff[1];
+}
+
+void LM75B::write16(char reg, unsigned short data)
+{
+    //Create a temporary buffer
+    char buff[3];
+
+    //Load the register address and 16-bit data
+    buff[0] = reg;
+    buff[1] = data >> 8;
+    buff[2] = data;
+
+    //Write the data
+    m_I2C.write(m_ADDR, buff, 3);
+}
+
+float LM75B::readAlertTempHelper(char reg)
+{
+    //Signed return value
+    short value;
+
+    //Read the 9-bit raw temperature value
+    value = read16(reg) >> 7;
+
+    //Sign extend negative numbers
+    if (value & (1 << 8))
+        value |= 0xFF00;
+
+    //Return the temperature in °C
+    return value * 0.5;
+}
+
+void LM75B::writeAlertTempHelper(char reg, float temp)
+{
+    //Range limit temp
+    if (temp < -55.0)
+        temp = -55.0;
+    else if (temp > 125.0)
+        temp = 125.0;
+
+    //Extract and shift the signed integer
+    short value = temp * 2;
+    value <<= 7;
+
+    //Send the new value
+    write16(reg, value);
+}

--- a/LM75B/LM75B.h
+++ b/LM75B/LM75B.h
@@ -1,0 +1,223 @@
+/* LM75B Driver Library
+ * Copyright (c) 2013 Neil Thiessen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LM75B_H
+#define LM75B_H
+
+#include "mbed.h"
+
+/** LM75B class.
+ *  Used for controlling an LM75B temperature sensor connected via I2C.
+ *
+ * Example:
+ * @code
+ * #include "mbed.h"
+ * #include "LM75B.h"
+ *
+ * //Create an LM75B object at the default address (ADDRESS_0)
+ * LM75B sensor(p28, p27);
+ *
+ * int main()
+ * {
+ *     //Try to open the LM75B
+ *     if (sensor.open()) {
+ *         printf("Device detected!\n");
+ *
+ *         while (1) {
+ *             //Print the current temperature
+ *             printf("Temp = %.3f\n", (float)sensor);
+ *
+ *             //Sleep for 0.5 seconds
+ *             wait(0.5);
+ *         }
+ *     } else {
+ *         error("Device not detected!\n");
+ *     }
+ * }
+ * @endcode
+ */
+class LM75B
+{
+public:
+    /** Represents the different I2C address possibilities for the LM75B
+     */
+    enum Address {
+        ADDRESS_0 = (0x48 << 1),    /**< A[2:0] pins = 000 */
+        ADDRESS_1 = (0x49 << 1),    /**< A[2:0] pins = 001 */
+        ADDRESS_2 = (0x4A << 1),    /**< A[2:0] pins = 010 */
+        ADDRESS_3 = (0x4B << 1),    /**< A[2:0] pins = 011 */
+        ADDRESS_4 = (0x4C << 1),    /**< A[2:0] pins = 100 */
+        ADDRESS_5 = (0x4D << 1),    /**< A[2:0] pins = 101 */
+        ADDRESS_6 = (0x4E << 1),    /**< A[2:0] pins = 110 */
+        ADDRESS_7 = (0x4F << 1)     /**< A[2:0] pins = 111 */
+    };
+
+    /** Represents the power mode of the LM75B
+     */
+    enum PowerMode {
+        POWER_NORMAL,   /**< Chip is enabled and samples every 100ms */
+        POWER_SHUTDOWN  /**< Chip is in low-power shutdown mode */
+    };
+
+    /** Represents OS pin mode of the LM75B
+     */
+    enum OSMode {
+        OS_COMPARATOR,  /**< OS is asserted when the temperature reaches the alert threshold, and de-asserted when the temperature drops below the alert hysteresis threshold */
+        OS_INTERRUPT    /**< OS is asserted when the temperature reaches the alert threshold, or drops below the alert hysteresis threshold, and only de-asserted when a register has been read */
+    };
+
+    /** Represents OS pin polarity of the LM75B
+     */
+    enum OSPolarity {
+        OS_ACTIVE_LOW,  /**< OS is a logic low when asserted, and a logic high when de-asserted */
+        OS_ACTIVE_HIGH  /**< OS is a logic high when asserted, and a logic low when de-asserted */
+    };
+
+    /** Represents OS pin fault queue length of the LM75B
+     */
+    enum OSFaultQueue {
+        OS_FAULT_QUEUE_1,   /**< OS is asserted after 1 fault */
+        OS_FAULT_QUEUE_2,   /**< OS is asserted after 2 consecutive faults */
+        OS_FAULT_QUEUE_4,   /**< OS is asserted after 4 consecutive faults */
+        OS_FAULT_QUEUE_6    /**< OS is asserted after 6 consecutive faults */
+    };
+
+    /** Create an LM75B object connected to the specified I2C pins with the specified I2C slave address
+     *
+     * @param sda The I2C data pin.
+     * @param scl The I2C clock pin.
+     * @param addr The I2C slave address (defaults to ADDRESS_0).
+     * @param hz The I2C bus frequency (defaults to 400kHz).
+     */
+    LM75B(PinName sda, PinName scl, Address addr = ADDRESS_0, int hz = 400000);
+
+    /** Probe for the LM75B and indicate if it's present on the bus
+     *
+     * @returns
+     *   'true' if the device exists on the bus,
+     *   'false' if the device doesn't exist on the bus.
+     */
+    bool open();
+
+    /** Get the current power mode of the LM75B
+     *
+     * @returns The current power mode as a PowerMode enum.
+     */
+    LM75B::PowerMode powerMode();
+
+    /** Set the power mode of the LM75B
+     *
+     * @param mode The new power mode as a PowerMode enum.
+     */
+    void powerMode(PowerMode mode);
+
+    /** Get the current OS pin mode of the LM75B
+     *
+     * @returns The current OS pin mode as an OSMode enum.
+     */
+    LM75B::OSMode osMode();
+
+    /** Set the OS pin mode of the LM75B
+     *
+     * @param mode The new OS pin mode as an OSMode enum.
+     */
+    void osMode(OSMode mode);
+
+    /** Get the current OS pin polarity of the LM75B
+     *
+     * @returns The current OS pin polarity as an OSPolarity enum.
+     */
+    LM75B::OSPolarity osPolarity();
+
+    /** Set the OS pin polarity of the LM75B
+     *
+     * @param polarity The new OS pin polarity as an OSPolarity enum.
+     */
+    void osPolarity(OSPolarity polarity);
+
+    /** Get the current OS pin fault queue length of the LM75B
+     *
+     * @returns The current OS pin fault queue length as an OSFaultQueue enum.
+     */
+    LM75B::OSFaultQueue osFaultQueue();
+
+    /** Set the OS pin fault queue length of the LM75B
+     *
+     * @param queue The new OS pin fault queue length as an OSFaultQueue enum.
+     */
+    void osFaultQueue(OSFaultQueue queue);
+
+    /** Get the current alert temperature threshold of the LM75B
+     *
+     * @returns The current alert temperature threshold in °C.
+     */
+    float alertTemp();
+
+    /** Set the alert temperature threshold of the LM75B
+     *
+     * @param temp The new alert temperature threshold in °C.
+     */
+    void alertTemp(float temp);
+
+    /** Get the current alert temperature hysteresis threshold of the LM75B
+     *
+     * @returns The current alert temperature hysteresis threshold in °C.
+     */
+    float alertHyst();
+
+    /** Set the alert temperature hysteresis threshold of the LM75B
+     *
+     * @param temp The new alert temperature hysteresis threshold in °C.
+     */
+    void alertHyst(float temp);
+
+    /** Get the current temperature measurement of the LM75B
+     *
+     * @returns The current temperature measurement in °C.
+     */
+    float temp();
+
+#ifdef MBED_OPERATORS
+    /** A shorthand for temp()
+     *
+     * @returns The current temperature measurement in °C.
+     */
+    operator float();
+#endif
+
+private:
+    //I2C register addresses
+    enum Register {
+        REG_TEMP    = 0x00,
+        REG_CONF    = 0x01,
+        REG_THYST   = 0x02,
+        REG_TOS     = 0x03
+    };
+
+    //Member variables
+    I2C m_I2C;
+    const int m_ADDR;
+
+    //Internal functions
+    char read8(char reg);
+    void write8(char reg, char data);
+    unsigned short read16(char reg);
+    void write16(char reg, unsigned short data);
+    float readAlertTempHelper(char reg);
+    void writeAlertTempHelper(char reg, float temp);
+};
+
+#endif

--- a/LM75B/LM75B.h
+++ b/LM75B/LM75B.h
@@ -161,10 +161,18 @@ public:
     void osFaultQueue(OSFaultQueue queue);
 
     /** Get the current alert temperature threshold of the LM75B
+     *  using the complete I2C read transaction API
      *
      * @returns The current alert temperature threshold in °C.
      */
-    float alertTemp();
+    float alertTemp_CT();
+    
+    /** Get the current alert temperature threshold of the LM75B
+     *  using the single byte I2C read transaction API
+     *
+     * @returns The current alert temperature threshold in °C.
+     */
+    float alertTemp_BT();
 
     /** Set the alert temperature threshold of the LM75B
      *
@@ -173,10 +181,18 @@ public:
     void alertTemp(float temp);
 
     /** Get the current alert temperature hysteresis threshold of the LM75B
+     *  using the complete I2C read transaction API
      *
      * @returns The current alert temperature hysteresis threshold in °C.
      */
-    float alertHyst();
+    float alertHyst_CT();
+    
+    /** Get the current alert temperature hysteresis threshold of the LM75B
+     *  using the single byte I2C read transaction API
+     *
+     * @returns The current alert temperature hysteresis threshold in °C.
+     */
+    float alertHyst_BT();
 
     /** Set the alert temperature hysteresis threshold of the LM75B
      *
@@ -185,10 +201,18 @@ public:
     void alertHyst(float temp);
 
     /** Get the current temperature measurement of the LM75B
+     *  using the complete I2C read transaction API
      *
      * @returns The current temperature measurement in °C.
      */
-    float temp();
+    float temp_CT();
+    
+    /** Get the current temperature measurement of the LM75B
+     *  using the single byte I2C read transaction API
+     *
+     * @returns The current temperature measurement in °C.
+     */
+    float temp_BT();
 
 #ifdef MBED_OPERATORS
     /** A shorthand for temp()
@@ -214,9 +238,11 @@ private:
     //Internal functions
     char read8(char reg);
     void write8(char reg, char data);
-    unsigned short read16(char reg);
+    unsigned short read16_CT(char reg);
+    unsigned short read16_BT(char reg);
     void write16(char reg, unsigned short data);
-    float readAlertTempHelper(char reg);
+    float readAlertTempHelper_CT(char reg);
+    float readAlertTempHelper_BT(char reg);
     void writeAlertTempHelper(char reg, float temp);
 };
 


### PR DESCRIPTION
This is an updated version of #80. The extra mercurial files have been removed and history has been simplified. Otherwise the content is identical to #80.