### PR TITLE
ARMC6 compilation error on ci-test-shield, use correct hash of I2CEeprom

### DIFF
--- a/I2CEeprom.lib
+++ b/I2CEeprom.lib
@@ -1,1 +1,1 @@
-https://developer.mbed.org/users/mbed_official/code/I2CEeprom/#973c4289c44c
+https://developer.mbed.org/users/mbed_official/code/I2CEeprom/#c3d4caec943a


### PR DESCRIPTION
ARMC6 compilation error on ci-test-shield.
Fix in https://os.mbed.com/users/mbed_official/code/I2CEeprom/.
In I2CEeprom.lib should be used correct hash.

@MarceloSalazar @0xc0170  @donatieng 