### PR TITLE
Update files with latest mbed-os 

### DIFF
--- a/ci_test_config.h
+++ b/ci_test_config.h
@@ -16,7 +16,7 @@
 #ifndef CI_TEST_CONFIG_H
 #define CI_TEST_CONFIG_H
 
-#include "utest_serial.h"
+#include "utest_print.h"
 
 #if defined(MBED_CONF_APP_DEBUG_MSG) && (MBED_CONF_APP_DEBUG_MSG != 0)
 #define DEBUG_PRINTF(...) do { utest_printf(__VA_ARGS__); } while(0)

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a8d1d26fa76a27263cc9a69f65df45e3458517a5
+https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7


### PR DESCRIPTION
- `utest_serial.h` is replaced with `utest_print.h`
- update mbed-os to 5.15.0 release