### PR TITLE
Remove mbed wait deprecated API usage

### DIFF
--- a/TESTS/API/BusInOut/BusInOut.cpp
+++ b/TESTS/API/BusInOut/BusInOut.cpp
@@ -57,9 +57,9 @@ void businout_define_test(){
         x = (x<<1) +1;
         bio1.output();
         bio1 = x;
-        wait(1);
+        thread_sleep_for(1000);
         bio2.input();
-        wait(1);
+        thread_sleep_for(1000);
         volatile int y = bio2.read();
         DEBUG_PRINTF("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
         TEST_ASSERT_MESSAGE(y == x,"Value read on bus does not equal value written. ");
@@ -70,9 +70,9 @@ void businout_define_test(){
         x = (x<<1) +1;
         bio2.output();
         bio2 = x;
-        wait(1);
+        thread_sleep_for(1000);
         bio1.input();
-        wait(1);
+        thread_sleep_for(1000);
         volatile int y = bio1.read();
         DEBUG_PRINTF("\r\n*********\r\nvalue of x,bio is: 0x%x, 0x%x\r\n********\r\n",x,y);
         TEST_ASSERT_MESSAGE(y == x,"Value read on bus does not equal value written. ");

--- a/TESTS/API/InterruptIn/InterruptIn.cpp
+++ b/TESTS/API/InterruptIn/InterruptIn.cpp
@@ -50,7 +50,7 @@ void InterruptInTest()
     result = false;
     intin.rise(cbfn);
     dout = 1;
-    wait(0); // dummy wait to get volatile result value
+    thread_sleep_for(0); // dummy wait to get volatile result value
     DEBUG_PRINTF("Value of result is : %d\n",result);
     TEST_ASSERT_MESSAGE(result,"cbfn was not triggered on rising edge of pin");
 
@@ -60,7 +60,7 @@ void InterruptInTest()
     result = false;
     intin.fall(cbfn);
     dout = 0;
-    wait(0); // dummy wait to get volatile result value
+    thread_sleep_for(0); // dummy wait to get volatile result value
     DEBUG_PRINTF("Value of result is : %d\n",result);
     TEST_ASSERT_MESSAGE(result,"cbfn was not triggered on falling edge of pin");
 }

--- a/TESTS/API/PWM_fall/PWM_fall.cpp
+++ b/TESTS/API/PWM_fall/PWM_fall.cpp
@@ -47,7 +47,7 @@ void PWM_Period_Test(){
   
   //Start Testing
   pwm.write(0.5f); // 50% duty cycle
-  wait_ms(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
+  thread_sleep_for(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
   iin.disable_irq(); // This is here because otherwise it fails on some platforms
   int fc = fall_count; // grab the numbers to work with as the pwm may continue going
 

--- a/TESTS/API/PWM_rise/PWM_rise.cpp
+++ b/TESTS/API/PWM_rise/PWM_rise.cpp
@@ -47,7 +47,7 @@ void PWM_Period_Test(){
   
   //Start Testing
   pwm.write(0.5f); // 50% duty cycle
-  wait_ms(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
+  thread_sleep_for(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
   iin.disable_irq(); // This is here because otherwise it fails on some platforms
   int rc = rise_count; // grab the numbers to work with as the pwm may continue going
 

--- a/TESTS/API/PWM_rise_fall/PWM_rise_fall.cpp
+++ b/TESTS/API/PWM_rise_fall/PWM_rise_fall.cpp
@@ -69,7 +69,7 @@ void PWM_Duty_slave(PinName pwm_out_pin, PinName int_in_pin, int period_in_ms, f
   pwm.period((float)period_in_ms / 1000); // set PWM period
   duty_timer.start();
   pwm.write(duty_cycle_percent); // set duty cycle
-  wait_ms(NUM_TESTS*period_in_ms);
+  thread_sleep_for(NUM_TESTS*period_in_ms);
   iin.disable_irq(); // This is here because otherwise it fails on some platforms
   duty_timer.stop();
 
@@ -130,7 +130,7 @@ void PWM_Period_Test(){
   
   //Start Testing
   pwm.write(0.5f); // 50% duty cycle
-  wait_ms(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
+  thread_sleep_for(num_tests * period_in_miliseconds); // wait for pwm to run and counts to add up
   iin.disable_irq(); // This is here because otherwise it fails on some platforms
   int rc = rise_count; // grab the numbers to work with as the pwm may continue going
   int fc = fall_count;

--- a/TESTS/concurrent/Comms/Comms.cpp
+++ b/TESTS/concurrent/Comms/Comms.cpp
@@ -119,7 +119,7 @@ void test_multiple_threads()
     Multi_Thread_ID = ThisThread::get_id();                               // update thread id for this thread
     Thread_I2C.start(callback(test_I2C));                             // kick off threads
     Thread_SPI.start(callback(test_SPI));                             // kick off threads
-    wait(0.1);                                                        // allow time for debug print statements to complete.
+    thread_sleep_for(100);                                                        // allow time for debug print statements to complete.
 
     // Use this to wait for both signaling events to occur
     // Internaly the code is doing something like this:

--- a/TESTS/concurrent/GPIO/GPIO.cpp
+++ b/TESTS/concurrent/GPIO/GPIO.cpp
@@ -86,7 +86,7 @@ void GPIO_Test()
         int_out = 0;
         int_in.rise(cbfn);
         int_out = 1;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(Result,"cbfn was not triggered on rising edge of pin");
 
         // Falling Edge InterruptIn test
@@ -94,7 +94,7 @@ void GPIO_Test()
         int_out = 1;
         int_in.fall(cbfn);
         int_out = 0;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(Result,"cbfn was not triggered on falling edge of pin");
     }
 }

--- a/TESTS/concurrent/Mixed/Mixed.cpp
+++ b/TESTS/concurrent/Mixed/Mixed.cpp
@@ -168,7 +168,7 @@ void test_GPIO()
         int_out = 0;
         int_in.rise(cbfn);
         int_out = 1;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(GPIO_Result,"cbfn was not triggered on rising edge of pin");
 
         // Falling Edge InterruptIn test
@@ -176,7 +176,7 @@ void test_GPIO()
         int_out = 1;
         int_in.fall(cbfn);
         int_out = 0;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(GPIO_Result,"cbfn was not triggered on falling edge of pin");
     }
     osSignalSet(Multi_Thread_ID, 0x4);                                // signal completion of thread
@@ -191,7 +191,7 @@ void test_multiple_threads()
     Thread_I2C.start(callback(test_I2C));                             // kick off threads
     Thread_SPI.start(callback(test_SPI));                             // kick off threads
     Thread_GPIO.start(callback(test_GPIO));                           // kick off threads
-    wait(0.1);                                                        // allow time for debug print statements to complete.
+    thread_sleep_for(100);                                                        // allow time for debug print statements to complete.
 
     // Use this to wait for both signaling events to occur
     // Internaly the code is doing something like this:
@@ -261,7 +261,7 @@ void test_single_thread()
         int_out = 0;
         int_in.rise(cbfn);
         int_out = 1;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(GPIO_Result,"cbfn was not triggered on rising edge of pin");
 
         // Falling Edge InterruptIn test
@@ -269,7 +269,7 @@ void test_single_thread()
         int_out = 1;
         int_in.fall(cbfn);
         int_out = 0;
-        wait(0); // dummy wait to get volatile result value
+        thread_sleep_for(0); // dummy wait to get volatile result value
         TEST_ASSERT_MESSAGE(GPIO_Result,"cbfn was not triggered on falling edge of pin");
 
         // Write to EEPROM using I2C


### PR DESCRIPTION
`wait` and `wait_ms` are removed from Mbed OS source in the [PR#12572](https://github.com/ARMmbed/mbed-os/pull/12572), so modified source to use thread_sleep_for API.

### Reviewers <!-- Optional -->
@evedon, @maciejbocianski, @jamesbeyond