### PR TITLE
Update deprecated Thread API 

### DIFF
--- a/TESTS/concurrent/Comms/Comms.cpp
+++ b/TESTS/concurrent/Comms/Comms.cpp
@@ -114,7 +114,7 @@ void test_SPI()
 // test I2C and SPI APIs concurrently in multiple threads
 void test_multiple_threads()
 {
-    Multi_Thread_ID = Thread::gettid();                               // update thread id for this thread
+    Multi_Thread_ID = ThisThread::get_id();                               // update thread id for this thread
     Thread_I2C.start(callback(test_I2C));                             // kick off threads
     Thread_SPI.start(callback(test_SPI));                             // kick off threads
     wait(0.1);                                                        // allow time for debug print statements to complete.

--- a/TESTS/concurrent/Mixed/Mixed.cpp
+++ b/TESTS/concurrent/Mixed/Mixed.cpp
@@ -185,7 +185,7 @@ void test_GPIO()
 
 void test_multiple_threads()
 {
-    Multi_Thread_ID = Thread::gettid();                               // update thread id for this thread
+    Multi_Thread_ID = ThisThread::get_id();                               // update thread id for this thread
     Thread_I2C.start(callback(test_I2C));                             // kick off threads
     Thread_SPI.start(callback(test_SPI));                             // kick off threads
     Thread_GPIO.start(callback(test_GPIO));                           // kick off threads


### PR DESCRIPTION
Some thread API deprecated in ARMmbed/mbed-os#12142
This PR change `Thread::gettid` to `ThisThread::get_id`