### PR TITLE
Analogin API tests: remove float print

### DIFF
--- a/TESTS/API/AnalogIn/AnalogIn.cpp
+++ b/TESTS/API/AnalogIn/AnalogIn.cpp
@@ -37,16 +37,14 @@ void AnalogInput_Test()
     int x = 0;
     int y= 0;
     outputs = 0;
-    float prev_value = 0;
+    unsigned short prev_value = 0;
     for(x = 0; x<5; x++) {
-        DEBUG_PRINTF("X=%d\n",x);
-        prev_value = ain.read();
+        prev_value = ain.read_u16();
         y = (y<<1) + 1;
         outputs = y;
-        DEBUG_PRINTF("outputs=0x%x\nprevValue=%f\nain=%f\n\n",y,prev_value,ain.read());
-        TEST_ASSERT_MESSAGE(ain.read() > prev_value,"Analog Input did not increment. Check that you have assigned valid pins in mbed_app.json file")
+        DEBUG_PRINTF("X=%d outputs=0x%x prevValue=%u ain=%u\n", x, y, prev_value, ain.read_u16());
+        TEST_ASSERT_MESSAGE(ain.read_u16() > prev_value,"Analog Input did not increment. Check that you have assigned valid pins in mbed_app.json file")
     }
-    DEBUG_PRINTF("Finished the Test\n");
     TEST_ASSERT(true);
 }
 


### PR DESCRIPTION
Hi

In mbed_app.json, set "DEBUG_MSG" to 1

````
$ mbed test -t ARMC6 -m NUCLEO_H743ZI2 -v -n tests-api-analogin
...
[1591354106.84][CONN][RXD] >>> Running case #1: 'Analog Input on AIN_0'...
[1591354106.89][CONN][INF] found KV pair in stream: {{__testcase_start;Analog Input on AIN_0}}, queued...
[1591354106.90][CONN][RXD] X=0
[1591354106.91][CONN][RXD] outputs=0x1
[1591354106.92][CONN][RXD] prevValue=%f
[1591354106.93][CONN][RXD] ain=%f
...
````

==> float are not printed

With correction:

````
$ mbed test -t ARMC6 -m NUCLEO_H743ZI2 -v -n tests-api-analogin
...
[1591354231.35][CONN][RXD] >>> Running case #1: 'Analog Input on AIN_0'...
[1591354231.41][CONN][INF] found KV pair in stream: {{__testcase_start;Analog Input on AIN_0}}, queued...
[1591354231.44][CONN][RXD] X=0 outputs=0x1 prevValue=80 ain=13308
[1591354231.49][CONN][RXD] X=1 outputs=0x3 prevValue=13338 ain=26099
[1591354231.53][CONN][RXD] X=2 outputs=0x7 prevValue=26114 ain=39359
[1591354231.57][CONN][RXD] X=3 outputs=0xf prevValue=39483 ain=52393
[1591354231.62][CONN][RXD] X=4 outputs=0x1f prevValue=52414 ain=65467
[1591354231.67][CONN][INF] found KV pair in stream: {{__testcase_finish;Analog Input on AIN_0;1;0}}, queued...
[1591354231.72][CONN][RXD] >>> 'Analog Input on AIN_0': 1 passed, 0 failed
...
````



