### PR TITLE
tests-assumptions-pwmout: remove unused InterruptIn

### DIFF
--- a/TESTS/assumptions/PwmOut/PwmOut.cpp
+++ b/TESTS/assumptions/PwmOut/PwmOut.cpp
@@ -51,7 +51,6 @@ void pwm_interrupt_timer_test()
     Timer timer;
     PwmOut pwm(MBED_CONF_APP_PWM_0);
     InterruptIn x(MBED_CONF_APP_DIO_2);
-    InterruptIn y(MBED_CONF_APP_DIO_4);
     x.rise(cbfn_rise);
     x.fall(cbfn_fall);
     fall_count = 0;


### PR DESCRIPTION
Quick patch to remove unused line.


PS: Issue detected during https://github.com/ARMmbed/mbed-os/pull/14843 validation :-)